### PR TITLE
Games with missing dev Uuid

### DIFF
--- a/Games missing Dev Uuid
+++ b/Games missing Dev Uuid
@@ -1,0 +1,84 @@
+Hero Generations                                                      air.com.brodie.herogenerations
+Furfur and Nublo                                                      air.com.devilishgames.furfurAndNublo
+Tower Invaders                                                        brokenbyte.TowerInvadersOUYA
+Sheep in Hell                                                         cm.david.sheepinhell
+Elliot Quest                                                          com.ansimuz.ElliotQuest
+Epic Flappy                                                           com.ArgenzioGames.EpicFlappy
+28 Invisible Mazes                                                    com.AwesomeEnterprises.InvisibleMazes
+Massive Cleavage vs Zombies                                           com.AwesomeEnterprises.MassiveCleavageVsZombies
+Zombie Trek Driver Survival                                           com.blisscomedia.ZombieTrekDriverSurvival
+Polarity: Partners In Crime                                           com.bluebox.PolarityCoop
+bob's game                                                            com.bobsgame.bg
+Santa's Special Delivery                                              com.ceruleangames.santasspecialdelivery
+Catlateral Damage                                                     com.ChrisChung.CatlateralDamage
+Sector Strike                                                         com.clapfootgames.sectorstrike
+in Emergency                                                          com.craftinglegends.inemergency
+MouseCraft                                                            com.crunchingkoalas.MouseCraft
+Attacking Zegeta                                                      com.denysoft.attackingzegeta
+360 Hover Parking                                                     com.devilishgames.hoverparking
+Police Cars Parking                                                   com.devilishgames.pcp
+Shopping Mall Parking                                                 com.devilishgames.smp
+The Secret of Universe Alpha                                          com.Dreamzle.UniverseAlpha
+Overdroy                                                              com.faurigames.overdroy
+Globulous                                                             com.firestartergames.globulousfree
+Cyclone                                                               com.focusonfungames.cyclonefull
+Soccertron                                                            com.forgottensystems.soccertron
+3T Games Compilation                                                  com.gamesq.compil
+3T Games Compilation 2                                                com.gamesr.compil2
+3T Games Compilation 3                                                com.gamess.compil3
+Frankystein                                                           com.gamest.franky
+Billy's Job                                                           com.gamesu.billy
+Mechanician Alex 2                                                    com.gamesv.alex2
+Karsus                                                                com.gamesw.karsus
+3T Games Compilation 4                                                com.gamesx.compil4
+Andros In Time                                                        com.gamesz.andros
+Lazy Caverns Attack                                                   com.gamezz.lattack
+iO                                                                    com.gamious.namethegame
+Alpha Wave                                                            com.hardlinestudios.alphawave
+Rage Runner                                                           com.hypercanestudios.ragerunner
+Excavator Simulator PRO                                               com.idriscelik.excavatorsimulatorpro
+MartyrX                                                               com.idriscelik.martyrx
+Johnny Adolf - The Floppy Duck                                        com.indievision.johnnyadolf
+The Jackbox Party Pack                                                com.jackboxgames.JackboxPartyLoaderFull
+ROBOCAT 02 II DUO / PI JUDGEMENT DAYS XxXTURBOXxX EDITION DX          com.JacobSirotta.ROBOCAT2TEDX
+enyo                                                                  com.jslgames.enyo
+Multispace                                                            com.kankibros.multispace
+The Bananatree Brothers                                               com.krisattfield.thebananatreebrothers
+Inkanians                                                             com.kronbits.inkanians
+Tales of Illyria                                                      com.littlekillerz.ringstrail
+Forsaken Planet                                                       com.LOOT.ForsakenPlanet
+The Mystery of Crimson Manor                                          com.mediacitygames.games.cmanor
+Jumpman Forever Beta 1                                                com.midnightryder.jumpmanforever
+Jumpman Forever                                                       com.midnightryder.jumpmanforeverfull
+Knight & Damsel                                                       com.mkultra.kdgame
+Boson X                                                               com.muandheyo.bosonx
+LSD Kitty FORCE                                                       com.nightsharts.LSDKittyFORCE
+Discovery                                                             com.noowanda.discovery
+Super Indie Karts                                                     com.oneleggedseagull.superindiekarts
+Cashtronauts                                                          com.PixelsAndPoutine.Cashtronauts
+Mechanic Escape                                                       com.playdigious.mechanicescape
+DEUS EX MACHINA GAME OF THE YEAR 30th ANNIVERSARY COLLECTOR'S EDITION com.potassiumfrog.deusexmachina
+Craft King                                                            com.quadowl.craftking
+Explosive Dinosaurs                                                   com.rawrlab.explosivedinosaurs
+XD: No crosswalk                                                      com.rawrlab.mnohaypasodepeatones
+XD: Mini Pang! (beta)                                                 com.rawrlab.mpang
+Unearthed: Trail of Ibn Battuta                                       com.semaphore.unearthedep1ouya
+Ice Brawlers Live                                                     com.sheldonmacdonald.icebrawlerslive
+Babylon 2055 Pinball                                                  com.shine_research.babylon_2055_pinball
+Quantic Pinball                                                       com.shine_research.quantic_pinball
+Fishy Rush                                                            com.silengames.fishyrush
+Road Guide Test Sim                                                   com.sparcksoft.roadguide
+Minimon 3D                                                            com.terra.minimon3d
+Wrong Title 2                                                         com.thebancast.Love
+Time To Die: Dungeons                                                 com.timetodiegames.dungeons
+Craftfield                                                            com.toet.CanvasLand
+Killing Floor: Calamity                                               com.Tripwire.Calamity
+3D Checkers for OUYA                                                  com.ttssoftware.checkers
+3D Reversi for OUYA                                                   com.ttssoftware.reversi
+SlotCar Getaway                                                       com.turbonuke.slotcargetaway
+bubblr - dummy in trouble                                             de.philweb.bubblr
+Tales of Illyria:Beyond the Iron Wall                                 ep2.littlekillerz.ringstrail
+Super Puzzle Platformer Deluxe                                        evil.corptron.SPPD
+Push the Fluffies                                                     magory.push
+Miracle Fly                                                           miracle.fly.elagotech
+Joe Danger                                                            uk.co.hellogames.jdtouch


### PR DESCRIPTION
How to help: Run `adb logcat` and go launch the game. May need to purchase something? Logcat will show the developer UUID. 

Go to the "classic" folder and find the corresponding packageName for the game and edit that file. Change the Devleoper UUID from 00000000-... to whatever was displayed by logcat.
Finally, remove the game from this 'games missing dev UUID' file so no one else goes looking for that game.