### PR TITLE
SPMC - A improved version of XBMC to OUYA

### DIFF
--- a/new/com.semperpax.spmc.json
+++ b/new/com.semperpax.spmc.json
@@ -10,7 +10,6 @@
         "Entertainment",
         "Video"
     ],
-
     "releases": [
         {
             "name": "14.2.0",
@@ -21,7 +20,8 @@
             "url": "https://archive.org/download/spmc-armeabi-v7a_14.2.0/spmc-armeabi-v7a_14.2.0.apk",
             "size": 64544494,
             "md5sum": "6ad3bb50cf0f5bff35f543e2d7017d86",
-
+            "publicSize": 0,
+            "nativeSize": 0,
         }
     ],
 
@@ -49,9 +49,8 @@
     "inAppPurchases": false,
     "overview": "Released in April 2015 by Koying.",
     "premium": false,
-
     "rating": {
         "likeCount": 0,
-        "average": 0,
+        "average": 0.0,
         "count": 0
     },

--- a/new/com.semperpax.spmc.json
+++ b/new/com.semperpax.spmc.json
@@ -32,7 +32,6 @@
             "url": "https://archive.org/download/spmc-armeabi-v7a_14.2.0/ouya_icon.png",
             "thumb": "https://archive.org/download/spmc-armeabi-v7a_14.2.0/ouya_icon_thumb.jpg"
         },
-
     ],
 
     "developer": {

--- a/new/com.semperpax.spmc.json
+++ b/new/com.semperpax.spmc.json
@@ -1,0 +1,57 @@
+{
+    "packageName": "com.semperpax.spmc",
+    "title": "SPMC 14.2.0",
+    "description": "Semper Media Center (SPMC in short) is a android-minded fork of Kodi, by the former Kodi android maintainer, Koying",
+    "players": [
+        1
+    ],
+    "genres": [
+        "App",
+        "Entertainment",
+        "Video"
+    ],
+
+    "releases": [
+        {
+            "name": "14.2.0",
+            "versionCode": 0,
+            "uuid": "f2a95744-ebea-11ea-adc1-0242ac120002",
+            "date": "2020-09-01T00:34:51Z",
+            "latest": true,
+            "url": "https://archive.org/download/spmc-armeabi-v7a_14.2.0/spmc-armeabi-v7a_14.2.0.apk",
+            "size": 64544494,
+            "md5sum": "6ad3bb50cf0f5bff35f543e2d7017d86",
+
+        }
+    ],
+
+    "discover": "https://archive.org/download/spmc-armeabi-v7a_14.2.0/ouya_icon.png",
+    "media": [
+        {
+            "type": "image",
+            "url": "https://archive.org/download/spmc-armeabi-v7a_14.2.0/ouya_icon.png",
+            "thumb": "https://archive.org/download/spmc-armeabi-v7a_14.2.0/ouya_icon_thumb.jpg"
+        },
+
+    ],
+
+    "developer": {
+        "uuid": "00000000-ebea-11ea-adc1-0242ac120002",
+        "name": "Koying",
+        "supportEmail": "null",
+        "supportPhone": "null",
+        "founder": false
+    },
+
+    "contentRating": "Everyone",
+    "website": "http://spmc.semperpax.com/",
+    "firstPublishedAt": "2013-11-23T07:46:00Z",
+    "inAppPurchases": false,
+    "overview": "Released in April 2015 by Koying.",
+    "premium": false,
+
+    "rating": {
+        "likeCount": 0,
+        "average": 0,
+        "count": 0
+    },


### PR DESCRIPTION
It is SPMC 14.2.0, the latest version that works on OUYA. It has better support for codecs than the XBMC version for OUYA.