### PR TITLE
Updating and fixing packages

### DIFF
--- a/classic/com.retroarch.json
+++ b/classic/com.retroarch.json
@@ -1,7 +1,7 @@
 {
-    "packageName": "com.retroarch",
+    "packageName": "com.retroarch.ra32",
     "title": "RetroArch",
-    "description": "RetroArch is a powerful engine that allows you to:\r\n\r\n* Play games (retro and more current ones)\r\n* Watch movies (soon)\r\n* Other stuff (augmented reality, etc) (soon)\r\n\r\nIt comes with its own built-in collection of applications to provide you with a 'one-stop-shop' for entertainment.",
+    "description": "ATTENTION: If you already have the OUYA's version installed, you must uninstall it first before install this new version.\r\n\r\nRetroArch is a powerful engine that allows you to:\r\n\r\n* Play games (retro and more current ones)\r\n* Watch movies (soon)\r\n* Other stuff (augmented reality, etc) (soon)\r\n\r\nIt comes with its own built-in collection of applications to provide you with a 'one-stop-shop' for entertainment.",
     "players": [
         1
     ],
@@ -9,6 +9,18 @@
         "Emulator"
     ],
     "releases": [
+        {
+            "name": "1.8.5_GIT",
+            "versionCode": 0,
+            "uuid": "78e9b078-02a8-4ca5-9053-81fe2af4df43",
+            "date": "2021-02-25T00:15:00Z",
+            "url": "https://archive.org/download/retroarch-ouya-signed/RetroArch-v1_8_5-OUYA-signed.apk",
+            "size": 96937894,
+            "md5sum": "a21a62315fecb89ef79bf87fa1037acb",
+            "latest": true,
+            "cert_fingerprint": "8E:35:B6:10:84:BA:FA:94:83:1A:3C:93:8B:CA:27:A1:9A:5E:7E:F2:05:67:FE:DF:16:91:71:63:18:E3:16:C0",
+            "cert_subject": "C = BR, ST = Minas Gerais, L = Belo Horizonte, O = OUYA Saviors, OU = Discord, CN = Zachary Foxx"
+        },
         {
             "name": "1.0.0.2",
             "versionCode": 0,
@@ -19,7 +31,7 @@
             "md5sum": "922919e21f02155784ac4b379096854b",
             "publicSize": 713261,
             "nativeSize": 1169736,
-            "latest": true,
+            "latest": false,
             "cert_fingerprint": "D7:A5:EA:B3:09:02:C9:B2:77:5A:F6:FB:4E:AC:2D:29:4A:64:63:4F:B4:7D:D1:38:2B:C3:AC:5B:F6:69:98:2E",
             "cert_subject": "O = Libretro"
         }

--- a/classic/com.retroarch.json
+++ b/classic/com.retroarch.json
@@ -17,6 +17,8 @@
             "url": "https://archive.org/download/retroarch-ouya-signed/RetroArch-v1_8_5-OUYA-signed.apk",
             "size": 96937894,
             "md5sum": "a21a62315fecb89ef79bf87fa1037acb",
+            "publicSize": 0,
+            "nativeSize": 0,
             "latest": true,
             "cert_fingerprint": "8E:35:B6:10:84:BA:FA:94:83:1A:3C:93:8B:CA:27:A1:9A:5E:7E:F2:05:67:FE:DF:16:91:71:63:18:E3:16:C0",
             "cert_subject": "C = BR, ST = Minas Gerais, L = Belo Horizonte, O = OUYA Saviors, OU = Discord, CN = Zachary Foxx"

--- a/classic/com.retroarch.json
+++ b/classic/com.retroarch.json
@@ -14,7 +14,7 @@
             "versionCode": 0,
             "uuid": "78e9b078-02a8-4ca5-9053-81fe2af4df43",
             "date": "2021-02-25T00:15:00Z",
-            "url": "https://archive.org/download/retroarch-ouya-signed/RetroArch-v1_8_5-OUYA-signed.apk",
+            "url": "https://archive.org/download/retroarch-ouya-signed/RetroArch-v1.8.5-OUYA-signed.apk",
             "size": 96937894,
             "md5sum": "a21a62315fecb89ef79bf87fa1037acb",
             "publicSize": 0,

--- a/classic/com.seleuco.mame4droid_0139u1.json
+++ b/classic/com.seleuco.mame4droid_0139u1.json
@@ -1,7 +1,7 @@
 {
-    "packageName": "com.seleuco.mame4droid_0139u1",
+    "packageName": "com.seleuco.mame4droid",
     "title": "MAME4droid (0.139u1)",
-    "description": "MAME4droid (0.139u1) is developed by David Valdeita (Seleuco), port of MAME 0.139 emulator by Nicola Salmoria and TEAM. MAME4droid (0.139u1) emulates arcade games supported by original MAME 0.139u1.\n* MAME4droid is an EMULATOR and DOES NOT INCLUDE ROMS OR COPYRIGHTED MATERIAL OF ANY KIND.\nThis version emulates over 8000 different romsets.\n\nNew on 1.8\nAdded selectable HQx image enhancer. \nAdded a new custom BIOS setting to set an alternate BIOS like unibios on Neogeo. \nNew Help by Shane R. Monroe. \nSome serious bugs fixed.\n\nNew on 1.7\nAdded android.intent.action.VIEW filter to open ROM files from a URI file scheme.\nImproved overlay (scanlines) rendering.\nAdded selectable true color rendering (improves artwork rendering).",
+    "description": "MAME4droid (0.139u1) is developed by David Valdeita (Seleuco), port of MAME 0.139u1 emulator by Nicola Salmoria and TEAM. MAME4droid (0.139u1) emulates arcade games supported by original MAME 0.139u1.\r\n\r\nATTENTION: If you already have the OUYA's version installed, you must uninstall it first before install this new version\r\n\r\nThis MAME4droid version is targeted to Dual-Core devices, because it is based on a high specs 2010 PC MAME build. Anyway don't expect arcade games of the 90 to work at full speed. With some games that are really bad optimized (like outrun or mk series) you will need at least a 1.5 ghz dual-core device (Cortex A15).\r\n\r\nThis is related to MAME build used, since it is targeted to high specs PC's as i said before.This version emulates over 8000 different romsets.\r\n\r\nPlease, try to understand that that with that amount of games, some will run better than others and some might not even run with MAME4droid.",
     "players": [
         1
     ],
@@ -9,6 +9,20 @@
         "Emulator"
     ],
     "releases": [
+        {
+            "name": "1.15.2",
+            "versionCode": 0,
+            "uuid": "b0e57029-07be-4f47-babc-83b50ce902f3",
+            "date": "2021-02-25T02:01:00Z",
+            "url": "https://archive.org/download/mame4droid-ouya/MAME4droid_0.139u1-1.15.2-release.apk",
+            "size": 38717543,
+            "md5sum": "fe20b5591ed8f59659cb3e7db15edf60",
+            "publicSize": 0,
+            "nativeSize": 0,
+            "latest": true,
+            "cert_fingerprint": "EF:D5:B9:C0:58:C1:21:ED:97:F3:FD:89:21:12:B6:00:F6:D1:9B:C2:9B:EE:F7:47:40:0C:E0:BB:0D:25:1C:40",
+            "cert_subject": "CN = Seleuco"
+        },
         {
             "name": "1.8",
             "versionCode": 0,
@@ -19,7 +33,7 @@
             "md5sum": "02051c1f5f63a42f7776bc6bcccfa179",
             "publicSize": 4572584,
             "nativeSize": 45781568,
-            "latest": true,
+            "latest": false,
             "cert_fingerprint": "EF:D5:B9:C0:58:C1:21:ED:97:F3:FD:89:21:12:B6:00:F6:D1:9B:C2:9B:EE:F7:47:40:0C:E0:BB:0D:25:1C:40",
             "cert_subject": "CN = Seleuco"
         },

--- a/new/com.semperpax.spmc.json
+++ b/new/com.semperpax.spmc.json
@@ -1,6 +1,6 @@
 {
     "packageName": "com.semperpax.spmc",
-    "title": "SPMC 14.2.0",
+    "title": "SPMC",
     "description": "Semper Media Center (SPMC in short) is a android-minded fork of Kodi, by the former Kodi android maintainer, Koying",
     "players": [
         1

--- a/new/org.schabi.newpipelegacy.json
+++ b/new/org.schabi.newpipelegacy.json
@@ -1,7 +1,7 @@
 {
     "packageName": "org.schabi.newpipelegacy",
     "title": "NewPipe Legacy",
-    "description": "NewPipe Legacy Lightweight YouTube frontend for OS versions 4.x.\r\n\r\nATTENTION: If you are at version 0.18.6 and want to update, you must uninstall that version first.\r\n\r\nNewPipe does not use any Google framework libraries, or the YouTube API. It only parses the website in order to gain the information it needs. Therefore this app can be used on devices without Google Services installed. Also, you don't need a YouTube account to use NewPipe, and it's FLOSS.",
+    "description": "NewPipe Legacy Lightweight YouTube frontend for OS versions 4.x.\r\n\r\nATTENTION: If you installed the version 0.20.8 before, please uninstall and install again.\r\n\r\nIf you are at version 0.18.6 and want to update, you must uninstall that version first.\r\n\r\nNewPipe does not use any Google framework libraries, or the YouTube API. It only parses the website in order to gain the information it needs. Therefore this app can be used on devices without Google Services installed. Also, you don't need a YouTube account to use NewPipe, and it's FLOSS.",
     "players": [
         1
     ],
@@ -18,8 +18,8 @@
             "date": "2021-02-07T19:51:00Z",
             "latest": true,
             "url": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-v0.20.8-OUYA-signed.apk",
-            "size": 8357555,
-            "md5sum": "0ebd1f5a158ce1f4993b611b13eee947",
+            "size": 8353232,
+            "md5sum": "25e9d7bc026b7a63bea451860d990709",
             "publicSize": 0,
             "nativeSize": 0,
             "cert_fingerprint": "8E:35:B6:10:84:BA:FA:94:83:1A:3C:93:8B:CA:27:A1:9A:5E:7E:F2:05:67:FE:DF:16:91:71:63:18:E3:16:C0",
@@ -32,8 +32,8 @@
             "date": "2020-09-05T20:36:00Z",
             "latest": false,
             "url": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-v0.18.6-OUYA-signed.apk",
-            "size": 7174018,
-            "md5sum": "a51da5c6f72440b02d25f97158eed300",
+            "size": 7176586,
+            "md5sum": "eb6ffff6653d099aba002bd10f04389e",
             "publicSize": 0,
             "nativeSize": 0,
             "cert_fingerprint": "8E:35:B6:10:84:BA:FA:94:83:1A:3C:93:8B:CA:27:A1:9A:5E:7E:F2:05:67:FE:DF:16:91:71:63:18:E3:16:C0",


### PR DESCRIPTION
Updates and fixes:

Retroarch:
- Updated to version 1.8.5_GIT;
- Included ouya_icon.png;
- Signed due to the inclusion of the icon (This is necessary);
- Included an alert for those who installed the version of OUYA before to uninstall that version before.

NewPipe Legacy:
- Fixed packages;
- Included an alert for those who installed version 0.20.8 before to uninstall and reinstall the package.

MAME4droid:
- Updated to version 1.15.2
- Included an alert for those who installed the version of OUYA before to uninstall that version before.

SPMC:
- Just updated the title of the package, excluding version information.