### PR TITLE
Updating RetroArch, Mupen64PlusAE and adding Mupen64Plus FZ Edition

### DIFF
--- a/classic/com.retroarch.ra32.json
+++ b/classic/com.retroarch.ra32.json
@@ -10,6 +10,20 @@
     ],
     "releases": [
         {
+            "name": "1.9.1_GIT",
+            "versionCode": 0,
+            "uuid": "08904453-a3de-4fc7-8479-20e512bec0e3",
+            "date": "2021-04-06T21:16:00Z",
+            "url": "https://archive.org/download/retroarch-ouya-signed/RetroArch-v1.9.1-OUYA-signed.apk",
+            "size": 143633610,
+            "md5sum": "2f7d0e337adcee0264d4eb44a7875c03",
+            "publicSize": 0,
+            "nativeSize": 0,
+            "latest": true,
+            "cert_fingerprint": "8E:35:B6:10:84:BA:FA:94:83:1A:3C:93:8B:CA:27:A1:9A:5E:7E:F2:05:67:FE:DF:16:91:71:63:18:E3:16:C0",
+            "cert_subject": "C = BR, ST = Minas Gerais, L = Belo Horizonte, O = OUYA Saviors, OU = Discord, CN = Zachary Foxx"
+        },
+        {
             "name": "1.8.5_GIT",
             "versionCode": 0,
             "uuid": "78e9b078-02a8-4ca5-9053-81fe2af4df43",
@@ -19,7 +33,7 @@
             "md5sum": "a21a62315fecb89ef79bf87fa1037acb",
             "publicSize": 0,
             "nativeSize": 0,
-            "latest": true,
+            "latest": false,
             "cert_fingerprint": "8E:35:B6:10:84:BA:FA:94:83:1A:3C:93:8B:CA:27:A1:9A:5E:7E:F2:05:67:FE:DF:16:91:71:63:18:E3:16:C0",
             "cert_subject": "C = BR, ST = Minas Gerais, L = Belo Horizonte, O = OUYA Saviors, OU = Discord, CN = Zachary Foxx"
         },

--- a/classic/fzurita.android.mupen64plusfz.json
+++ b/classic/fzurita.android.mupen64plusfz.json
@@ -1,0 +1,88 @@
+{
+    "packageName": "org.mupen64plusae.v3.fzurita",
+    "title": "Mupen64Plus FZ Emulator",
+    "description": "M64Plus FZ is an updated build from Mupen64Plus AE from the same sources, which was a port of the popular open-source Nintendo 64 emulator \"Mupen64Plus\"! This emulator allows you to play your backed-up N64 games (called ROMs) on your OUYA. It does NOT come with any ROMs (you must provide them yourself).r\n\r\n* This is the last version compatible with OUYA. You SHOULD UNINSTALL previous versions before install this version.\r\n* There will be issues with specific games or devices.\r\n* Not all games work, but most do.\r\n* For games that do work, you may have to try different video plugins.\r\n* Although this version includes the new GLideN64, the OUYA is not powerful enough.\r\n* Not all video plugins will work with every device, and there could be glitches.\r\n* There are many missing translations. It may be better to stick with English.",
+    "players": [
+        1
+    ],
+    "genres": [
+        "Emulator"
+    ],
+    "releases": [
+        {
+            "name": "3.0.121 (beta)",
+            "versionCode": 0,
+            "uuid": "d649b0d7-45bf-424b-b58d-428524be0ec4",
+            "date": "2021-03-14T18:31:00Z",
+            "url": "https://archive.org/download/M64Plus_FZ_Emulator/org.mupen64plusae.v3.fzurita-121.apk",
+            "size": 15305161,
+            "md5sum": "a20d0135f8fa9b02ae07a9b4ab68d021",
+            "publicSize": 0,
+            "nativeSize": 0,
+            "latest": true,
+            "cert_fingerprint": "1B:CE:02:7B:A4:E9:29:35:B2:21:76:46:87:54:E0:CE:7B:F7:94:90:AC:82:55:07:E3:95:26:5C:12:F5:31:6D",
+            "cert_subject": "CN=Francisco Zurita, L=Liverpool, ST=NY, C=US"
+        }
+    ],
+    "discover": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/discover",
+    "media": [
+        {
+            "type": "image",
+            "url": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-1",
+            "thumb": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-1-thumb"
+        },
+        {
+            "type": "image",
+            "url": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-2",
+            "thumb": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-2-thumb"
+        },
+        {
+            "type": "image",
+            "url": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-3",
+            "thumb": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-3-thumb"
+        },
+        {
+            "type": "image",
+            "url": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-4",
+            "thumb": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-4-thumb"
+        },
+        {
+            "type": "image",
+            "url": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-5",
+            "thumb": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-5-thumb"
+        },
+        {
+            "type": "image",
+            "url": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-6",
+            "thumb": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-6-thumb"
+        },
+        {
+            "type": "image",
+            "url": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-7",
+            "thumb": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-7-thumb"
+        },
+        {
+            "type": "image",
+            "url": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-8",
+            "thumb": "http://ouya.cweiske.de/game-images/paulscode.android.mupen64plusae/screenshot-8-thumb"
+        }
+    ],
+    "developer": {
+        "uuid": "9bfdd9ac-d30b-4334-b89d-3648251c0a59",
+        "name": "Francisco Zurita",
+        "supportEmail": "fzurita@gmail.com",
+        "supportPhone": null,
+        "founder": false
+    },
+    "contentRating": "Everyone",
+    "website": "https://github.com/mupen64plus-ae/mupen64plus-ae",
+    "firstPublishedAt": "2016-07-22T01:23:09Z",
+    "inAppPurchases": false,
+    "overview": "Released in July 2016 by Francisco Zurita.",
+    "premium": false,
+    "rating": {
+        "likeCount": 0,
+        "average": 0,
+        "count": 0
+    }
+}

--- a/classic/paulscode.android.mupen64plusae.json
+++ b/classic/paulscode.android.mupen64plusae.json
@@ -10,6 +10,20 @@
     ],
     "releases": [
         {
+            "name": "2.4.4",
+            "versionCode": 0,
+            "uuid": "51d2e302-6b4b-4375-bd5b-297419ecdf9c",
+            "date": "2021-04-03T20:35:30Z",
+            "url": "https://archive.org/download/M64Plus_FZ_Emulator/Mupen64%20Plus%20AE_2.4.4_paulscode.android.mupen64plusae.apk",
+            "size": 12415986,
+            "md5sum": "b28e41d057cde0f982b8f6f331b99466",
+            "publicSize": 0,
+            "nativeSize": 0,
+            "latest": true,
+            "cert_fingerprint": "45:C3:84:C5:EE:BC:FF:05:38:55:F4:68:E2:41:3E:21:46:6A:F3:CA:A6:DA:12:20:96:66:E9:40:A5:BA:7B:2C",
+            "cert_subject": "C = US, ST = Kansas, L = Halstead, O = PaulsCode.Com, OU = Android, CN = Paul Lamb"
+        },
+        {
             "name": "2.4.2",
             "versionCode": 0,
             "uuid": "669630ea-e29d-404f-acae-9f8553929921",
@@ -19,7 +33,7 @@
             "md5sum": "bb95858a8e9ae36a0237295be917ad36",
             "publicSize": 0,
             "nativeSize": 0,
-            "latest": true,
+            "latest": false,
             "cert_fingerprint": "45:C3:84:C5:EE:BC:FF:05:38:55:F4:68:E2:41:3E:21:46:6A:F3:CA:A6:DA:12:20:96:66:E9:40:A5:BA:7B:2C",
             "cert_subject": "C = US, ST = Kansas, L = Halstead, O = PaulsCode.Com, OU = Android, CN = Paul Lamb"
         },


### PR DESCRIPTION
As agreed:

- Update of Mupen64Plus AE to the latest version; and
- Adding the Mupen64Plus FZ Edition.

For the FZ Edition, I used the same image links used to the AE edition in the json file.