### PR TITLE
Updates: ePSXe and NewPipe Legacy

### DIFF
--- a/new/com.epsxe.ePSXe.json
+++ b/new/com.epsxe.ePSXe.json
@@ -24,26 +24,26 @@
             "cert_subject": "OU=OUYA SAVIOR, O=OUYA"
         }
     ],
-    "discover": "https://archive.org/download/epsxe-ouya/discover.png",
+    "discover": "https://archive.org/download/epsxe-ouya/discover.jpg",
     "media": [
         {
             "type": "image",
-            "url": "https://archive.org/download/epsxe-ouya/epsxe-01.png",
+            "url": "https://archive.org/download/epsxe-ouya/epsxe-01.jpg",
             "thumb": "https://archive.org/download/epsxe-ouya/epsxe-01-thumb.png"
         },
         {
             "type": "image",
-            "url": "https://archive.org/download/epsxe-ouya/epsxe-02.png",
+            "url": "https://archive.org/download/epsxe-ouya/epsxe-02.jpg",
             "thumb": "https://archive.org/download/epsxe-ouya/epsxe-02-thumb.png"
         },
         {
             "type": "image",
-            "url": "https://archive.org/download/epsxe-ouya/epsxe-03.png",
+            "url": "https://archive.org/download/epsxe-ouya/epsxe-03.jpg",
             "thumb": "https://archive.org/download/epsxe-ouya/epsxe-03-thumb.png"
         },
         {
             "type": "image",
-            "url": "https://archive.org/download/epsxe-ouya/epsxe-04.png",
+            "url": "https://archive.org/download/epsxe-ouya/epsxe-04.jpg",
             "thumb": "https://archive.org/download/epsxe-ouya/epsxe-04-thumb.png"
         }
     ],

--- a/new/org.schabi.newpipelegacy.preunified.json
+++ b/new/org.schabi.newpipelegacy.preunified.json
@@ -1,7 +1,7 @@
 {
-    "packageName": "org.schabi.newpipelegacy",
+    "packageName": "org.schabi.newpipelegacy.preunified",
     "title": "NewPipe Legacy",
-    "description": "NewPipe Legacy Lightweight YouTube frontend for OS versions 4.x.\r\n\r\nATTENTION: If you installed the version 0.20.8 before, please uninstall and install again.\r\n\r\nIf you are at version 0.18.6 and want to update, you must uninstall that version first.\r\n\r\nNewPipe does not use any Google framework libraries, or the YouTube API. It only parses the website in order to gain the information it needs. Therefore this app can be used on devices without Google Services installed. Also, you don't need a YouTube account to use NewPipe, and it's FLOSS.",
+    "description": "NewPipe Legacy Lightweight YouTube frontend for OS versions 4.x.\r\n\r\nWARNING: If you have NewPipe Legacy installed, clear the program cache and uninstall it before installing the new version.\r\n \r\nNewPipe doesn't use any Google framework libraries or YouTube API. It just parses the website to get the information it needs. Therefore, this app can be used on devices without Google Services installed. Also, you don't need a YouTube account to use NewPipe, and it's FLOSS.",
     "players": [
         1
     ],
@@ -12,11 +12,25 @@
     ],
     "releases": [
         {
+            "name": "0.21.13",
+            "versionCode": 100,
+            "uuid": "b2b12c67-03c7-4c9f-963a-801ad5564f5d",
+            "date": "2022-02-11T00:36:00Z",
+            "latest": true,
+            "url": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-v0.21.13-OUYA-signed.apk",
+            "size": 7855388,
+            "md5sum": "7e3e69d54c4d039da0d956957ebea22a",
+            "publicSize": 0,
+            "nativeSize": 0,
+            "cert_fingerprint": "8E:35:B6:10:84:BA:FA:94:83:1A:3C:93:8B:CA:27:A1:9A:5E:7E:F2:05:67:FE:DF:16:91:71:63:18:E3:16:C0",
+            "cert_subject": "C = BR, ST = Minas Gerais, L = Belo Horizonte, O = OUYA Saviors, OU = Discord, CN = Zachary Foxx"
+        },        
+        {
             "name": "0.20.8",
             "versionCode": 0,
             "uuid": "ba8e745f-d2b5-4827-9e31-96798311c9f2",
             "date": "2021-02-07T19:51:00Z",
-            "latest": true,
+            "latest": false,
             "url": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-v0.20.8-OUYA-signed.apk",
             "size": 8353232,
             "md5sum": "25e9d7bc026b7a63bea451860d990709",
@@ -40,17 +54,17 @@
             "cert_subject": "C = BR, ST = Minas Gerais, L = Belo Horizonte, O = OUYA Saviors, OU = Discord, CN = Zachary Foxx"
         }
     ],
-    "discover": "https://archive.org/download/new-pipe-legacy-ouya-signed/discover.png",
+    "discover": "https://archive.org/download/new-pipe-legacy-ouya-signed/discover.jpg",
     "media": [
         {
             "type": "image",
-            "url": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-01.png",
-            "thumb": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-thumb-01.png"
+            "url": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-01.jpg",
+            "thumb": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-thumb-01.jpg"
         },
         {
             "type": "image",
-            "url": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-02.png",
-            "thumb": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-thumb-02.png"
+            "url": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-02.jpg",
+            "thumb": "https://archive.org/download/new-pipe-legacy-ouya-signed/NewPipeLegacy-thumb-02.jpg"
         }
     ],
     "developer": {


### PR DESCRIPTION
**ePSXe:**

Changing the link to the discover and other screenshots, from png versions to jpg versions.

**NewPipe Legacy:**

Updating version from 0.20.8 to  0.21.13;
Updating description;
Changing "packageName" from "org.schabi.newpipelegacy" to "org.schabi.newpipelegacy.preunified" because the internal package name changed.
Changing the json file to match the package name.